### PR TITLE
Fetch remote refs before switching to target branch

### DIFF
--- a/ensure-regression-tests
+++ b/ensure-regression-tests
@@ -22,6 +22,7 @@ if [ -z "${target_branch}" ]; then
 fi
 
 # Checkout the branch that the pull request is targeting...
+git fetch
 git checkout "${target_branch}"
 
 # ...but revert the test code back to the pull request version


### PR DESCRIPTION
When a pull request isn't targeting the `master` branch Travis doesn't
have the required refs because it clones with the `--depth` option,
which means it only clones a single branch's history. To work around
this we need to perform a fetch before trying to switch to the target
branch.

Fixes https://github.com/everypolitician/ensure-regression-tests/issues/4