### PR TITLE
Fix script when PR targets non-default branch

### DIFF
--- a/ensure-regression-tests
+++ b/ensure-regression-tests
@@ -22,6 +22,7 @@ if [ -z "${target_branch}" ]; then
 fi
 
 # Checkout the branch that the pull request is targeting...
+git remote set-branches origin "${target_branch}"
 git fetch
 git checkout "${target_branch}"
 


### PR DESCRIPTION
When the pull request targets a branch that isn't the default in the repo the script was failing. This is because Travis does a shallow clone, which means it only tracks the default branch (normally `master`).

This change tells git to also track the branch the pull request targets, which means when we perform the fetch it will also get a copy of that branch.

Fixes #6 